### PR TITLE
Don't invalidate config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/lib/3ds-cmake/DevkitArm3DS.
 
 set(3dstris_VERSION_MAJOR 0)
 set(3dstris_VERSION_MINOR 9)
-set(3dstris_VERSION_PATCH 2)
+set(3dstris_VERSION_PATCH 3)
 set(3dstris_VERSION "${3dstris_VERSION_MAJOR}.${3dstris_VERSION_MINOR}.${3dstris_VERSION_PATCH}")
 
 project(

--- a/include/3dstris/config.hpp
+++ b/include/3dstris/config.hpp
@@ -19,12 +19,12 @@ struct Config {
 		writer.Uint(arr);
 
 		writer.String("dropTimer");
-		writer.Uint(arr);
+		writer.Uint(dropTimer);
 
 		writer.EndObject();
 	}
 
-	void save(const bool overwrite = true);
+	void save();
 	Games& getGames() noexcept;
 
 	u32 das = 200;
@@ -34,8 +34,10 @@ struct Config {
 	bool failed = false;
 
    private:
-	const FS_Path dirPath = fsMakePath(PATH_ASCII, "/3dstris");
-	const FS_Path configPath = fsMakePath(PATH_ASCII, "/3dstris/config.json");
+	const FS_Path homebrewPath = fsMakePath(PATH_ASCII, "/3ds/");
+	const FS_Path dirPath = fsMakePath(PATH_ASCII, "/3ds/3dstris");
+	const FS_Path configPath =
+		fsMakePath(PATH_ASCII, "/3ds/3dstris/config.json");
 
 	Games games;
 

--- a/include/3dstris/games.hpp
+++ b/include/3dstris/games.hpp
@@ -48,12 +48,12 @@ class Games {
 
 	const SavedGames& all() const noexcept;
 
-	void save(const bool overwrite = true);
+	void save();
 	void push(const SavedGame game);
 	bool failed;
 
    private:
-	FS_Path gamesPath = fsMakePath(PATH_ASCII, "/3dstris/games.json");
+	FS_Path gamesPath = fsMakePath(PATH_ASCII, "/3ds/3dstris/games.json");
 	SavedGames games;
 
 	FS_Archive sdmcArchive;

--- a/include/3dstris/util/text.hpp
+++ b/include/3dstris/util/text.hpp
@@ -30,7 +30,7 @@ class Text {
 
 	void setPos(const Pos pos) noexcept;
 
-	Vector2 getWH() const;
+	WH getWH() const;
 
 	void setColor(const Color color);
 	Color getColor() const noexcept;
@@ -43,7 +43,7 @@ class Text {
 	void draw(const float depth = 1) const;
 
    private:
-	Vector2 pos;
+	Pos pos;
 	Vector2 scale;
 	sds text = nullptr;
 	Color color;

--- a/src/games.cpp
+++ b/src/games.cpp
@@ -77,6 +77,7 @@ void Games::push(const SavedGame game) {
 void Games::save() {
 	rapidjson::StringBuffer sb;
 	rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
+	writer.SetMaxDecimalPlaces(4);
 
 	this->serialize(writer);
 

--- a/src/games.cpp
+++ b/src/games.cpp
@@ -8,9 +8,9 @@
 static bool fileExists(FS_Archive& archive, const FS_Path& path) {
 	Handle handle;
 
-	return !R_FAILED(
+	return R_SUCCEEDED(
 			   FSUSER_OpenFile(&handle, archive, path, FS_OPEN_READ, 0)) &&
-		   !R_FAILED(FSFILE_Close(handle));
+		   R_SUCCEEDED(FSFILE_Close(handle));
 }
 
 static bool validateJson(rapidjson::Document& doc) {
@@ -29,7 +29,7 @@ void Games::initialize(const FS_Archive sdmcArchive) {
 					FS_OPEN_WRITE | FS_OPEN_READ, 0);
 
 	if (!gamesFileExists) {
-		save(false);
+		save();
 	}
 
 	u64 fileSize;
@@ -74,23 +74,13 @@ void Games::push(const SavedGame game) {
 	std::sort(games.begin(), games.end(), std::less<SavedGame>());
 }
 
-void Games::save(const bool overwrite) {
-	if (overwrite) {
-		FSFILE_Close(gamesHandle);
-
-		FSUSER_DeleteFile(sdmcArchive, gamesPath);
-		FSUSER_CreateFile(sdmcArchive, gamesPath, 0, 0);
-
-		FSUSER_OpenFile(&gamesHandle, sdmcArchive, gamesPath,
-						FS_OPEN_WRITE | FS_OPEN_READ, 0);
-	}
-
+void Games::save() {
 	rapidjson::StringBuffer sb;
 	rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-	writer.SetMaxDecimalPlaces(4);
 
 	this->serialize(writer);
 
 	FSFILE_Write(gamesHandle, nullptr, 0, sb.GetString(), sb.GetLength(),
 				 FS_WRITE_FLUSH);
+	FSFILE_SetSize(gamesHandle, sb.GetLength());
 }

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -36,7 +36,7 @@ void Piece::reset(const PieceShape& shape, const PieceType type) {
 	rotation = 0;
 
 	_dead =
-		collides(0, 0);	 // piece is "dead" if it collides as soon as it spawns
+		collides(0, 0);  // piece is "dead" if it collides as soon as it spawns
 }
 
 void Piece::reset(const PieceType type) {
@@ -58,7 +58,7 @@ void Piece::set() {
 bool Piece::collides(const int offX, const int offY) const {
 	for (u32 y = 0; y < shape.size; ++y) {
 		for (u32 x = 0; x < shape.size; ++x) {
-			Vector2 offPos = {pos.x + x + offX, pos.y + y + offY};
+			Pos offPos = {pos.x + x + offX, pos.y + y + offY};
 			if (shape.shape[y * shape.size + x] &&
 				(!board.inside(offPos) ||
 				 board.get(offPos) != PieceType::NONE)) {
@@ -249,7 +249,7 @@ void Piece::updateMove(const double dt, const u32 kDown) {
 	};
 
 	bool moved =
-		_move(LEFT, dasTimer.x, KEY_LEFT);	// x is actually the left timer
+		_move(LEFT, dasTimer.x, KEY_LEFT);  // x is actually the left timer
 	if (!moved) {
 		_move(RIGHT, dasTimer.y, KEY_RIGHT);  // y is actually the right timer
 	}

--- a/src/states/ingame.cpp
+++ b/src/states/ingame.cpp
@@ -74,8 +74,9 @@ void Ingame::draw(const bool bottom) {
 		u32 y = 1;
 		for (u32 i = 0; i < upcoming; ++i) {
 			const auto& p = bag[i];
-			if (p == PieceType::I)
+			if (p == PieceType::I) {
 				--y;
+			}
 			Piece::draw(
 				{origin.x + (board.width + 1 + (p == PieceType::O)) * tileSize,
 				 origin.y + y * tileSize},

--- a/src/util/text.cpp
+++ b/src/util/text.cpp
@@ -1,7 +1,10 @@
 #include <3dstris/util/text.hpp>
 
 Text::Text(const sds text, const Color color)
-	: pos({0, 0}), scale({1, 1}), color(color), textBuffer(C2D_TextBufNew(64)) {
+	: pos({0, 0}),
+	  scale({1, 1}),
+	  color(color),
+	  textBuffer(C2D_TextBufNew(sdslen(text))) {
 	this->setText(text);
 }
 
@@ -16,7 +19,7 @@ Text::Text(const Text& other)
 	: pos(other.pos),
 	  scale(other.scale),
 	  color(other.color),
-	  textBuffer(C2D_TextBufNew(64)) {
+	  textBuffer(C2D_TextBufNew(sdslen(other.text))) {
 	this->setText(other.text);
 }
 
@@ -66,7 +69,10 @@ void Text::setText(const sds text) {
 	sdsfree(this->text);
 	this->text = text;
 
-	C2D_TextBufClear(this->textBuffer);
+	C2D_TextBufClear(textBuffer);
+	if (C2D_TextBufGetNumGlyphs(textBuffer) != sdslen(text)) {
+		textBuffer = C2D_TextBufResize(textBuffer, sdslen(text));
+	}
 
 	C2D_TextParse(&textObject, textBuffer, this->text);
 	C2D_TextOptimize(&textObject);


### PR DESCRIPTION
3DStris now saves its config/games in sdmc:/3ds/3dstris instead of sdmc:/3dstris
dropTimer is now saved correctly (it would previously save ARR instead)

The config is no longer invalidated if one or more of the values are invalid; instead those values are set to the default
Previously, 3DStris would incorrectly return 0 as the size of the config files even if they were just created; this is no longer the case (it required setting the size manually (FSFILE_SetSize) after saving)

More boring code cleanup

This is also the first PR to be merged into develop!! :tada: woo yeaah