### PR TITLE
Boring cleanup #4828942

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(3dstris_VERSION_MAJOR 1)
 set(3dstris_VERSION_MINOR 0)
-set(3dstris_VERSION_PATCH 2)
+set(3dstris_VERSION_PATCH 3)
 set(3dstris_VERSION "${3dstris_VERSION_MAJOR}.${3dstris_VERSION_MINOR}.${3dstris_VERSION_PATCH}")
 
 project(

--- a/include/3dstris/shapes.hpp
+++ b/include/3dstris/shapes.hpp
@@ -85,8 +85,8 @@ namespace Shapes {
 		0, 0, 0
 	}, 3};
 	// clang-format on
-};  // namespace Shapes
 
-static std::array<PieceShape, 7> shapes{Shapes::I, Shapes::O, Shapes::L,
-										Shapes::J, Shapes::S, Shapes::T,
-										Shapes::Z};
+	static std::array<PieceShape, 7> ALL{Shapes::I, Shapes::O, Shapes::L,
+										 Shapes::J, Shapes::S, Shapes::T,
+										 Shapes::Z};
+};  // namespace Shapes

--- a/include/3dstris/states/configscreen.hpp
+++ b/include/3dstris/states/configscreen.hpp
@@ -19,9 +19,9 @@ class ConfigScreen : public State {
 	Text title;
 	Text tipText;
 
-	Text dasText;
-	Text arrText;
-	Text dropTimerText;
+	Text dasLabel;
+	Text arrLabel;
+	Text dropTimerLabel;
 
 	Button& save;
 	Button& cancel;

--- a/include/3dstris/states/results.hpp
+++ b/include/3dstris/states/results.hpp
@@ -7,7 +7,6 @@
 class Results : public State {
    public:
 	Results(Ingame* parent);
-	Results(Ingame* parent, SavedGame&& saved);
 
 	void update(const double dt) override;
 	void draw(const bool bottom) override;

--- a/include/3dstris/states/sprint.hpp
+++ b/include/3dstris/states/sprint.hpp
@@ -6,6 +6,7 @@
 class Sprint : public Ingame {
    public:
 	Sprint();
+	~Sprint();
 
 	void update(const double dt) override;
 	void draw(const bool bottom) override;
@@ -13,6 +14,8 @@ class Sprint : public Ingame {
 	void reset() override;
 
    private:
+	const sds infoFormat;
+
 	Text infoText;
 	double time;
 

--- a/include/3dstris/states/sprintresults.hpp
+++ b/include/3dstris/states/sprintresults.hpp
@@ -8,6 +8,7 @@
 class SprintResults : public State {
    public:
 	SprintResults(Ingame* parent, SavedGame&& saved);
+	~SprintResults();
 
 	void update(const double dt) override;
 	void draw(const bool bottom) override;
@@ -17,6 +18,7 @@ class SprintResults : public State {
 
 	Ingame* parent;
 
+	const sds timeFormat;
 	Text timeText;
 
 	GUI gui;

--- a/include/3dstris/states/sprinttimes.hpp
+++ b/include/3dstris/states/sprinttimes.hpp
@@ -8,6 +8,7 @@
 class SprintTimes : public State {
    public:
 	SprintTimes();
+	~SprintTimes();
 
 	void update(const double dt) override;
 	void draw(const bool bottom) override;
@@ -24,6 +25,8 @@ class SprintTimes : public State {
 
 	void updateInfoText(const SavedGame& game);
 	void updateSelectedText();
+
+	const sds infoFormat;
 
 	GUI gui;
 	Panel panel;

--- a/romfs/lang/pl.json
+++ b/romfs/lang/pl.json
@@ -16,7 +16,7 @@
 	"sprint.times.nogames": "Brak rozgrywek w trybie Sprint.",
 	"sprint.times.table.time": "Czas",
 	"sprint.times.table.date": "Data",
-	"sprint.times.info": "Time: %.3fs\nPPS: %.2f\nDate: %s",
+	"sprint.times.info": "Czas: %.3fs\nPPS: %.2f\nData: %s",
 
 	"results.dead": "Koniec Gry",
 	"results.restart": "Restart",

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -8,7 +8,7 @@ Piece::Piece(Board& board, const PieceShape& shape, const PieceType type)
 }
 
 Piece::Piece(Board& board, const PieceType type)
-	: Piece(board, shapes[type], type) {
+	: Piece(board, Shapes::ALL[type], type) {
 	// Uhh
 }
 
@@ -39,7 +39,7 @@ void Piece::reset(const PieceShape& shape, const PieceType type) {
 }
 
 void Piece::reset(const PieceType type) {
-	reset(shapes[type], type);
+	reset(Shapes::ALL[type], type);
 }
 
 void Piece::set() {

--- a/src/states/configscreen.cpp
+++ b/src/states/configscreen.cpp
@@ -10,12 +10,12 @@ ConfigScreen::ConfigScreen()
 	  title(game.translate("settings.title")),
 	  tipText(game.translate("settings.tip")),
 
-	  dasText(game.translate("settings.das"), Pos{15, 50 - 35},
-			  Vector2{0.5f, 0.5f}),
-	  arrText(game.translate("settings.arr"), Pos{15, 100 - 35},
-			  Vector2{0.5f, 0.5f}),
-	  dropTimerText(game.translate("settings.droptimer"), Pos{15, 150 - 35},
-					Vector2{0.5f, 0.5f}),
+	  dasLabel(game.translate("settings.das"), Pos{15, 50 - 35},
+			   Vector2{0.5f, 0.5f}),
+	  arrLabel(game.translate("settings.arr"), Pos{15, 100 - 35},
+			   Vector2{0.5f, 0.5f}),
+	  dropTimerLabel(game.translate("settings.droptimer"), Pos{15, 150 - 35},
+					 Vector2{0.5f, 0.5f}),
 
 	  save(gui.add<Button>(Pos{10, BSCREEN_HEIGHT - 55}, WH{100, 50},
 						   game.translate("save"))),
@@ -82,8 +82,8 @@ void ConfigScreen::draw(const bool bottom) {
 
 		gui.draw();
 
-		dasText.draw();
-		arrText.draw();
-		dropTimerText.draw();
+		dasLabel.draw();
+		arrLabel.draw();
+		dropTimerLabel.draw();
 	}
 }

--- a/src/states/results.cpp
+++ b/src/states/results.cpp
@@ -18,16 +18,6 @@ Results::Results(Ingame* parent)
 	deadText.align(Text::Align::SCREEN_CENTER);
 }
 
-Results::Results(Ingame* parent, SavedGame&& saved) : Results(parent) {
-	deadText.setText(sdscatprintf(
-		sdsempty(), game.translate("results.sprint.time"), saved.time));
-	deadText.setScale({1.3f, 1.3f});
-	deadText.align(Text::Align::SCREEN_CENTER);
-
-	game.getGames().push(std::move(saved));
-	game.getGames().save();
-}
-
 void Results::update(const double dt) {
 	gui.update(dt);
 

--- a/src/states/sprint.cpp
+++ b/src/states/sprint.cpp
@@ -4,8 +4,16 @@
 #include <3dstris/states/sprint.hpp>
 #include <3dstris/states/sprintresults.hpp>
 
-Sprint::Sprint() : Ingame(), time(0.0) {
+Sprint::Sprint()
+	: Ingame(),
+	  infoFormat(game.translate("sprint.info")),
+	  time(0.0),
+	  startTimer(0.0) {
 	infoText.setPos({10, 10});
+}
+
+Sprint::~Sprint() {
+	sdsfree(infoFormat);
 }
 
 void Sprint::reset() {
@@ -42,9 +50,8 @@ void Sprint::update(const double dt) {
 
 	time += dt;
 
-	infoText.setText(sdscatprintf(sdsempty(), game.translate("sprint.info"),
-								  board.linesCleared(), time,
-								  board.droppedPieces() / time));
+	infoText.setText(sdscatprintf(sdsempty(), infoFormat, board.linesCleared(),
+								  time, board.droppedPieces() / time));
 
 	if (board.linesCleared() >= 20) {
 		game.pushState(make_unique<SprintResults>(

--- a/src/states/sprintresults.cpp
+++ b/src/states/sprintresults.cpp
@@ -6,8 +6,8 @@ SprintResults::SprintResults(Ingame* parent, SavedGame&& saved)
 	: State(),
 	  parent(parent),
 
-	  timeText(sdscatprintf(sdsempty(), game.translate("results.sprint.time"),
-							saved.time)),
+	  timeFormat(game.translate("results.sprint.time")),
+	  timeText(sdscatprintf(sdsempty(), timeFormat, saved.time)),
 
 	  restartButton(gui.add<Button>(Pos{-1, -1}, WH{150, 60},
 									game.translate("results.restart"),
@@ -23,6 +23,10 @@ SprintResults::SprintResults(Ingame* parent, SavedGame&& saved)
 
 	game.getGames().push(std::move(saved));
 	game.getGames().save();
+}
+
+SprintResults::~SprintResults() {
+	sdsfree(timeFormat);
 }
 
 void SprintResults::update(const double dt) {

--- a/src/states/sprinttimes.cpp
+++ b/src/states/sprinttimes.cpp
@@ -5,6 +5,8 @@
 
 SprintTimes::SprintTimes()
 	: State(),
+	  infoFormat(game.translate("sprint.times.info")),
+
 	  panel(gui, Pos{TABLE_X, TABLE_Y}, WH{TABLE_W, TABLE_H}, true),
 
 	  backButton(gui.add<Button>(Pos{-1, BSCREEN_HEIGHT - 60}, WH{100, 50},
@@ -33,6 +35,10 @@ SprintTimes::SprintTimes()
 	noGamesText.align(Text::Align::SCREEN_CENTER);
 	updateInfoText(games[selected]);
 	updateSelectedText();
+}
+
+SprintTimes::~SprintTimes() {
+	sdsfree(infoFormat);
 }
 
 void SprintTimes::genValues() {
@@ -155,7 +161,6 @@ void SprintTimes::updateSelectedText() {
 void SprintTimes::updateInfoText(const SavedGame& savedGame) {
 	char date[60];
 	savedGame.dateString(date, 60);
-	infoText.setText(sdscatprintf(sdsempty(),
-								  game.translate("sprint.times.info"),
-								  savedGame.time, savedGame.pps, date));
+	infoText.setText(sdscatprintf(sdsempty(), infoFormat, savedGame.time,
+								  savedGame.pps, date));
 }


### PR DESCRIPTION
Apparently, Sprint::update was allocating a new sds and never freeing it! How lovely. Let's try not to leak so much memory.
Initialize sprint timer; should fix the random instantaneous starts.
Bunch of other small tweaks and optimizations.

hahahahohohohehehe #69