### PR TITLE
String class

### DIFF
--- a/include/3dstris/config/l10n.hpp
+++ b/include/3dstris/config/l10n.hpp
@@ -6,6 +6,7 @@
 
 #include <3dstris/util/log.hpp>
 
+class String;
 class L10n final {
    public:
 	struct CompareString {
@@ -43,7 +44,7 @@ class L10n final {
 	void load(const char* __restrict path) noexcept;
 	rapidjson::Document loadJson(const char* __restrict path) noexcept;
 
-	sds get(const char* __restrict key) const noexcept;
+	String get(const char* __restrict key) const noexcept;
 
 	static size_t getFlag(Language language) noexcept;
 

--- a/include/3dstris/game.hpp
+++ b/include/3dstris/game.hpp
@@ -18,7 +18,7 @@ class Game {
 
 	bool isPressed(u32 kDown, Keybinds::Action action) const noexcept;
 
-	sds translate(const char* __restrict key) const noexcept;
+	String translate(const char* __restrict key) const noexcept;
 	void loadLanguage(L10n::Language language) noexcept;
 
 	C3D_RenderTarget* getTop() noexcept;

--- a/include/3dstris/gui/widgets/button.hpp
+++ b/include/3dstris/gui/widgets/button.hpp
@@ -7,12 +7,10 @@ class Button : public Widget {
    public:
 	enum class Flags { NONE, HCENTER, VCENTER, CENTER };
 
-	Button(GUI& parent, Pos pos, WH wh, sds text,
-		   Flags flags = Flags::NONE) noexcept;
-	Button(GUI& parent, Pos pos, WH wh, const char* __restrict text,
+	Button(GUI& parent, Pos pos, WH wh, String&& text = String::empty(),
 		   Flags flags = Flags::NONE) noexcept;
 
-	void setText(sds text) noexcept;
+	void setText(String&& text) noexcept;
 
 	void draw() const noexcept override;
 	void update(touchPosition touch, touchPosition previous) override;
@@ -21,6 +19,12 @@ class Button : public Widget {
 	bool pressed() noexcept;
 
    private:
+	inline void scaleAlignText() noexcept {
+		this->text.scale(wh.x, 0.7f);
+		this->text.align(Text::Align::CENTER, Pos{pos.x, pos.y},
+						 WH{wh.x, wh.y});
+	}
+
 	Text text;
 
 	bool held = false;

--- a/include/3dstris/gui/widgets/integerinputfield.hpp
+++ b/include/3dstris/gui/widgets/integerinputfield.hpp
@@ -17,17 +17,12 @@ class IntegerInputField final : public Widget {
 
    public:
 	IntegerInputField(GUI& _parent, const Pos _pos, const WH _wh,
-					  sds suffix = sdsempty()) noexcept
+					  String suffix = String::empty()) noexcept
 		: Widget(_parent, _pos, _wh), suffix(suffix), value(0) {
 		text.setX(pos.x + 3);
 
 		updateText();
 	}
-	IntegerInputField(GUI& _parent, const Pos _pos, const WH _wh,
-					  const char* __restrict suffix) noexcept
-		: IntegerInputField(_parent, _pos, _wh, sdsnew(suffix)) {}
-
-	~IntegerInputField() noexcept override { sdsfree(suffix); }
 
 	void draw() const noexcept override {
 		C2D_DrawRectSolid(pos.x, pos.y, 0, wh.x, wh.y,
@@ -84,7 +79,7 @@ class IntegerInputField final : public Widget {
 			sdscatfmt(sdsempty(), std::is_signed<T>::value ? "%I%S" : "%U%S",
 					  std::is_signed<T>::value ? static_cast<s64>(value)
 											   : static_cast<u64>(value),
-					  suffix));
+					  suffix.s));
 
 		const float textScale = std::min(text.getWH().y / wh.y, 0.5f);
 		text.setScale({textScale, textScale});
@@ -93,7 +88,7 @@ class IntegerInputField final : public Widget {
 	}
 
 	Text text;
-	const sds suffix;
+	const String suffix;
 
 	T value;
 

--- a/include/3dstris/gui/widgets/integerinputfield.hpp
+++ b/include/3dstris/gui/widgets/integerinputfield.hpp
@@ -75,11 +75,11 @@ class IntegerInputField final : public Widget {
 
    private:
 	void updateText() noexcept {
-		text.setText(
-			sdscatfmt(sdsempty(), std::is_signed<T>::value ? "%I%S" : "%U%S",
-					  std::is_signed<T>::value ? static_cast<s64>(value)
-											   : static_cast<u64>(value),
-					  suffix.s));
+		text.setText(String::fromFmt(std::is_signed<T>::value ? "%I%S" : "%U%S",
+									 std::is_signed<T>::value
+										 ? static_cast<s64>(value)
+										 : static_cast<u64>(value),
+									 suffix.s));
 
 		const float textScale = std::min(text.getWH().y / wh.y, 0.5f);
 		text.setScale({textScale, textScale});

--- a/include/3dstris/gui/widgets/togglebutton.hpp
+++ b/include/3dstris/gui/widgets/togglebutton.hpp
@@ -5,9 +5,8 @@
 class GUI;
 class ToggleButton final : public Button {
    public:
-	ToggleButton(GUI& parent, Pos pos, WH wh, sds text,
+	ToggleButton(GUI& parent, Pos pos, WH wh, String&& text,
 				 bool defaultValue) noexcept;
-	~ToggleButton() noexcept override;
 
 	void update(touchPosition touch, touchPosition previous) noexcept override;
 
@@ -16,7 +15,7 @@ class ToggleButton final : public Button {
    private:
 	using Button::setText;
 
-	sds text;
+	String text;
 
 	bool value;
 };

--- a/include/3dstris/states/game/sprint.hpp
+++ b/include/3dstris/states/game/sprint.hpp
@@ -6,7 +6,6 @@
 class Sprint final : public Ingame {
    public:
 	explicit Sprint(const u16 lines);
-	~Sprint() noexcept override;
 
 	void update(double dt) override;
 	void draw(bool bottom) override;
@@ -14,7 +13,7 @@ class Sprint final : public Ingame {
 	void reset() override;
 
    private:
-	const sds infoFormat;
+	const String infoFormat;
 
 	const u16 lines;
 

--- a/include/3dstris/states/game/sprintresults.hpp
+++ b/include/3dstris/states/game/sprintresults.hpp
@@ -6,7 +6,6 @@
 class SprintResults final : public State {
    public:
 	SprintResults(Ingame* parent, SavedGame&& saved);
-	~SprintResults() override;
 
 	void update(double dt) override;
 	void draw(bool bottom) override;
@@ -16,7 +15,7 @@ class SprintResults final : public State {
 
 	Ingame* parent;
 
-	const sds timeFormat;
+	const String timeFormat;
 	Text timeText;
 
 	GUI gui;

--- a/include/3dstris/states/menu/sprinttimes.hpp
+++ b/include/3dstris/states/menu/sprinttimes.hpp
@@ -7,7 +7,6 @@
 class SprintTimes final : public State {
    public:
 	SprintTimes();
-	~SprintTimes() noexcept override;
 
 	void update(double dt) override;
 	void draw(bool bottom) noexcept override;
@@ -26,7 +25,7 @@ class SprintTimes final : public State {
 	void updateInfoText(const SavedGame& game);
 	void updateSelectedText();
 
-	const sds infoFormat;
+	const String infoFormat;
 
 	GUI gui;
 	Panel panel;

--- a/include/3dstris/util.hpp
+++ b/include/3dstris/util.hpp
@@ -1,1 +1,0 @@
-#pragma once

--- a/include/3dstris/util/string.hpp
+++ b/include/3dstris/util/string.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <sds.h>
+
+struct String final {
+	static String empty() noexcept { return sdsempty(); }
+
+	String() noexcept : s(nullptr) {}
+	String(const char* __restrict str) noexcept : s(sdsnew(str)) {}
+	String(sds str) noexcept : s(str) {}
+
+	~String() noexcept { sdsfree(s); }
+	String(const String& other) noexcept : s(sdsnew(other.s)) {}
+	String(String&& other) noexcept : s(other.s) { other.s = nullptr; }
+	void operator=(const String& other) noexcept {
+		sdsfree(s);
+		s = sdsnew(other.s);
+	}
+	void operator=(String&& other) noexcept {
+		sdsfree(s);
+		s = other.s;
+		other.s = nullptr;
+	}
+
+	operator sds() const noexcept { return s; }
+
+	sds s;
+};

--- a/include/3dstris/util/string.hpp
+++ b/include/3dstris/util/string.hpp
@@ -5,6 +5,17 @@
 struct String final {
 	static String empty() noexcept { return sdsempty(); }
 
+	template <typename... Args>
+	static String fromFmt(const char* __restrict fmt, Args&&... args) noexcept {
+		return sdscatfmt(sdsempty(), fmt, args...);
+	}
+
+	template <typename... Args>
+	static String fromPrintf(const char* __restrict fmt,
+							 Args&&... args) noexcept {
+		return sdscatprintf(sdsempty(), fmt, args...);
+	}
+
 	String() noexcept : s(nullptr) {}
 	String(const char* __restrict str) noexcept : s(sdsnew(str)) {}
 	String(sds str) noexcept : s(str) {}

--- a/include/3dstris/util/text.hpp
+++ b/include/3dstris/util/text.hpp
@@ -5,23 +5,15 @@
 #include <3dstris/game.hpp>
 #include <3dstris/util/colorstextures.hpp>
 #include <3dstris/util/math.hpp>
+#include <3dstris/util/string.hpp>
 
 class Text {
    public:
 	enum class Align { CENTER, VCENTER, HCENTER, SCREEN_CENTER };
 
-	explicit Text(sds text = sdsempty(), Pos pos = Pos{},
+	explicit Text(String&& text = String::empty(), Pos pos = Pos{},
 				  Vector2f scale = {1, 1},
 				  const Color& color = Game::get().getTheme().text) noexcept;
-	explicit Text(const char* __restrict text, Pos pos = Pos{},
-				  Vector2f scale = {1, 1},
-				  const Color& color = Game::get().getTheme().text) noexcept;
-
-	~Text() noexcept;
-	Text(const Text& other) = delete;
-	Text(Text&& other) noexcept;
-	Text& operator=(const Text& other) = delete;
-	Text& operator=(Text&& other) = delete;
 
 	void draw(float depth = 1) const noexcept;
 
@@ -30,8 +22,8 @@ class Text {
 
 	void scale(float cw, float max) noexcept;
 
-	void setText(sds text) noexcept;
-	sds getText() const noexcept;
+	void setText(String&& text) noexcept;
+	const String& getText() const noexcept;
 
 	void setX(float x) noexcept;
 	float getX() const noexcept;
@@ -54,7 +46,7 @@ class Text {
 	Pos pos;
 	Vector2f _scale;
 
-	sds text = nullptr;
+	String text;
 	C2D_TextBuf textBuffer;
 	C2D_Text textObject;
 

--- a/src/config/l10n.cpp
+++ b/src/config/l10n.cpp
@@ -2,6 +2,7 @@
 #include <rapidjson/filereadstream.h>
 
 #include <3dstris/config/l10n.hpp>
+#include <3dstris/util/string.hpp>
 
 #define FLAG(lang) images_##lang##_idx
 
@@ -43,16 +44,16 @@ rapidjson::Document L10n::loadJson(const char* __restrict path) noexcept {
 	return document;
 }
 
-sds L10n::get(const char* __restrict key) const noexcept {
+String L10n::get(const char* __restrict key) const noexcept {
 	if (translations.HasMember(key)) {
-		return sdsnew(translations[key].GetString());
+		return translations[key].GetString();
 	} else if (!enTranslations.IsNull()) {
 		if (enTranslations.HasMember(key)) {
-			return sdsnew(enTranslations[key].GetString());
+			return enTranslations[key].GetString();
 		}
 	}
 
-	return sdsnew(key);
+	return key;
 }
 
 size_t L10n::getFlag(const Language language) noexcept {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9,12 +9,6 @@ Game::Game() noexcept {
 	C2D_Init(C2D_DEFAULT_MAX_OBJECTS);
 	C2D_Prepare();
 
-#ifndef NDEBUG
-	consoleDebugInit(debugDevice_3DMOO);
-	Log::get().setLevel(Log::Level::DEBUG);
-	Log::get().setQuiet(false);
-#endif
-
 	top = C2D_CreateScreenTarget(GFX_TOP, GFX_LEFT);
 	bottom = C2D_CreateScreenTarget(GFX_BOTTOM, GFX_LEFT);
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,6 +1,7 @@
 #include <3dstris/game.hpp>
 #include <3dstris/state.hpp>
 #include <3dstris/util/colorstextures.hpp>
+#include <3dstris/util/string.hpp>
 
 Game::Game() noexcept {
 	gfxInitDefault();
@@ -50,7 +51,7 @@ bool Game::isPressed(const u32 kDown, const Keybinds::Action action) const
 	return kDown & config.getKeybinds().get(action);
 }
 
-sds Game::translate(const char* __restrict key) const noexcept {
+String Game::translate(const char* __restrict key) const noexcept {
 	return config.getL10n().get(key);
 }
 void Game::loadLanguage(const L10n::Language language) noexcept {

--- a/src/gui/widgets/button.cpp
+++ b/src/gui/widgets/button.cpp
@@ -1,8 +1,8 @@
 #include <3dstris/gui.hpp>
 
-Button::Button(GUI& _parent, const Pos _pos, const WH _wh, sds text,
+Button::Button(GUI& _parent, const Pos _pos, const WH _wh, String&& text,
 			   const Flags flags) noexcept
-	: Widget(_parent, _pos, _wh), text() {
+	: Widget(_parent, _pos, _wh), text(std::forward<String>(text)) {
 	if (flags == Flags::HCENTER || flags == Flags::CENTER) {
 		pos.x = (parent.getWidth() - wh.x) / 2.0f;
 	}
@@ -10,18 +10,12 @@ Button::Button(GUI& _parent, const Pos _pos, const WH _wh, sds text,
 		pos.y = (parent.getHeight() - wh.y) / 2.0f;
 	}
 
-	setText(text);
+	scaleAlignText();
 }
 
-Button::Button(GUI& _parent, const Pos _pos, const WH _wh,
-			   const char* __restrict text, const Flags flags) noexcept
-	: Button::Button(_parent, _pos, _wh, sdsnew(text), flags) {}
-
-void Button::setText(sds text) noexcept {
-	this->text.setText(text);
-
-	this->text.scale(wh.x, 0.7f);
-	this->text.align(Text::Align::CENTER, Pos{pos.x, pos.y}, WH{wh.x, wh.y});
+void Button::setText(String&& text) noexcept {
+	this->text.setText(std::forward<String>(text));
+	scaleAlignText();
 }
 
 void Button::draw() const noexcept {

--- a/src/gui/widgets/keybindbutton.cpp
+++ b/src/gui/widgets/keybindbutton.cpp
@@ -24,7 +24,7 @@ const phmap::flat_hash_map<Keybinds::Key, const char*>
 KeybindButton::KeybindButton(GUI& _parent, const Pos _pos, const WH _wh,
 							 const Keybinds::Action action,
 							 Keybinds::Key& toSet) noexcept
-	: Button(_parent, _pos, _wh, sdsempty()),
+	: Button(_parent, _pos, _wh, String::empty()),
 	  action(action),
 	  key(toSet),
 	  toSet(toSet) {
@@ -74,5 +74,5 @@ void KeybindButton::reset() {
 }
 
 void KeybindButton::updateText() {
-	setText(sdsnew(KEY_TO_GLYPH.contains(key) ? KEY_TO_GLYPH.at(key) : "?"));
+	setText(KEY_TO_GLYPH.contains(key) ? KEY_TO_GLYPH.at(key) : "?");
 }

--- a/src/gui/widgets/togglebutton.cpp
+++ b/src/gui/widgets/togglebutton.cpp
@@ -1,20 +1,16 @@
 #include <3dstris/game.hpp>
 #include <3dstris/gui/widgets/togglebutton.hpp>
 
-static sds getText(sds text, const bool value) {
+static String getText(const String& text, const bool value) {
 	return sdscatfmt(sdsnew(text), ": %s",
-					 Game::get().translate(value ? "on" : "off"));
+					 Game::get().translate(value ? "on" : "off").s);
 }
 
-ToggleButton::ToggleButton(GUI& _parent, const Pos _pos, const WH _wh, sds text,
-						   const bool defaultValue) noexcept
+ToggleButton::ToggleButton(GUI& _parent, const Pos _pos, const WH _wh,
+						   String&& text, const bool defaultValue) noexcept
 	: Button(_parent, _pos, _wh, getText(text, defaultValue)),
 	  text(text),
 	  value(defaultValue) {}
-
-ToggleButton::~ToggleButton() noexcept {
-	sdsfree(text);
-}
 
 void ToggleButton::update(const touchPosition touch,
 						  const touchPosition previous) noexcept {

--- a/src/states/game/sprint.cpp
+++ b/src/states/game/sprint.cpp
@@ -16,14 +16,10 @@ Sprint::Sprint(const u16 lines)
 	infoText.setPos({10, 10});
 }
 
-Sprint::~Sprint() noexcept {
-	sdsfree(infoFormat);
-}
-
 void Sprint::reset() {
 	Ingame::reset();
 
-	infoText.setText(sdsempty());
+	infoText.setText(String::empty());
 
 	time = 0.0;
 	startTimer = 0.0;

--- a/src/states/game/sprint.cpp
+++ b/src/states/game/sprint.cpp
@@ -55,8 +55,8 @@ void Sprint::update(const double dt) {
 
 	time += dt;
 
-	infoText.setText(sdscatprintf(sdsempty(), infoFormat, board.linesCleared(),
-								  lines, time, board.droppedPieces() / time));
+	infoText.setText(String::fromPrintf(infoFormat, board.linesCleared(), lines,
+										time, board.droppedPieces() / time));
 
 	Ingame::update(dt);
 }

--- a/src/states/game/sprintresults.cpp
+++ b/src/states/game/sprintresults.cpp
@@ -7,7 +7,7 @@ SprintResults::SprintResults(Ingame* parent, SavedGame&& saved)
 	  parent(parent),
 
 	  timeFormat(game.translate("results.sprint.time")),
-	  timeText(sdscatprintf(sdsempty(), timeFormat, saved.time)),
+	  timeText(String::fromPrintf(timeFormat, saved.time)),
 
 	  restart(gui.add<Button>(Pos{}, WH{150, 60},
 							  game.translate("results.restart"),

--- a/src/states/game/sprintresults.cpp
+++ b/src/states/game/sprintresults.cpp
@@ -24,10 +24,6 @@ SprintResults::SprintResults(Ingame* parent, SavedGame&& saved)
 	game.getGames().save();
 }
 
-SprintResults::~SprintResults() {
-	sdsfree(timeFormat);
-}
-
 void SprintResults::update(const double dt) {
 	gui.update(dt);
 

--- a/src/states/menu/mainmenu.cpp
+++ b/src/states/menu/mainmenu.cpp
@@ -9,9 +9,8 @@
 
 MainMenu::MainMenu() noexcept
 	: State(),
-	  version(
-		  sdscatfmt(sdsempty(), "v%s-%s", _3DSTRIS_VERSION, _3DSTRIS_GIT_HASH),
-		  Pos{}, {0.5f, 0.5f}),
+	  version(String::fromFmt("v%s-%s", _3DSTRIS_VERSION, _3DSTRIS_GIT_HASH),
+			  Pos{}, {0.5f, 0.5f}),
 
 	  icon(C2D_SpriteSheetGetImage(game.getImageSheet(), images_icon_idx)),
 

--- a/src/states/menu/settings/gameplay.cpp
+++ b/src/states/menu/settings/gameplay.cpp
@@ -17,7 +17,7 @@ GameplaySettings::GameplaySettings() noexcept
 			  WH{100, 25}),
 	  nextTipText(
 		  sdscatfmt(sdsempty(), "%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_R),
-					game.translate("settings.visual.title")),
+					game.translate("settings.visual.title").s),
 		  Pos(SCREEN_WIDTH - 100 + 5, 0)),
 
 	  das(gui.add<IntegerInputField<u16>>(

--- a/src/states/menu/settings/gameplay.cpp
+++ b/src/states/menu/settings/gameplay.cpp
@@ -16,8 +16,8 @@ GameplaySettings::GameplaySettings() noexcept
 	  nextTip(gui, Pos(SCREEN_WIDTH - 100, SCREEN_HEIGHT - 25 - 25),
 			  WH{100, 25}),
 	  nextTipText(
-		  sdscatfmt(sdsempty(), "%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_R),
-					game.translate("settings.visual.title").s),
+		  String::fromFmt("%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_R),
+						  game.translate("settings.visual.title").s),
 		  Pos(SCREEN_WIDTH - 100 + 5, 0)),
 
 	  das(gui.add<IntegerInputField<u16>>(

--- a/src/states/menu/settings/visual.cpp
+++ b/src/states/menu/settings/visual.cpp
@@ -7,7 +7,7 @@ VisualSettings::VisualSettings() noexcept
 	  backTip(gui, Pos{0, SCREEN_HEIGHT - 25 - 25}, WH{100, 25}),
 	  backTipText(
 		  sdscatfmt(sdsempty(), "%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_L),
-					game.translate("settings.gameplay.title")),
+					game.translate("settings.gameplay.title").s),
 		  Pos{6, 0}),
 
 	  useTextures(gui.add<ToggleButton>(

--- a/src/states/menu/settings/visual.cpp
+++ b/src/states/menu/settings/visual.cpp
@@ -6,8 +6,8 @@ VisualSettings::VisualSettings() noexcept
 
 	  backTip(gui, Pos{0, SCREEN_HEIGHT - 25 - 25}, WH{100, 25}),
 	  backTipText(
-		  sdscatfmt(sdsempty(), "%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_L),
-					game.translate("settings.gameplay.title").s),
+		  String::fromFmt("%s %S", KeybindButton::KEY_TO_GLYPH.at(KEY_L),
+						  game.translate("settings.gameplay.title").s),
 		  Pos{6, 0}),
 
 	  useTextures(gui.add<ToggleButton>(

--- a/src/states/menu/sprinttimes.cpp
+++ b/src/states/menu/sprinttimes.cpp
@@ -54,7 +54,7 @@ void SprintTimes::genValues() {
 	for (u32 i = 0; i < std::min(games.size(), CELLS); ++i) {
 		const SavedGame& saved = games[i + topCell];
 
-		Text time(sdscatprintf(sdsempty(), "%.3fs", saved.time), Pos{},
+		Text time(String::fromPrintf("%.3fs", saved.time), Pos{},
 				  {0.8f, 0.8f});
 		time.align(Text::Align::CENTER,
 				   Pos{TABLE_X, TABLE_Y + CELL_H * (i + 1.0f)},
@@ -181,7 +181,7 @@ void SprintTimes::updateSelectedText() {
 void SprintTimes::updateInfoText(const SavedGame& saved) {
 	char date[60];
 	saved.dateString(date, 60);
-	page.setText(sdscatprintf(sdsempty(), infoFormat.s, saved.lines, saved.time,
+	page.setText(String::fromPrintf(infoFormat.s, saved.lines, saved.time,
 							  saved.pps, date));
 }
 

--- a/src/states/menu/sprinttimes.cpp
+++ b/src/states/menu/sprinttimes.cpp
@@ -15,8 +15,8 @@ SprintTimes::SprintTimes()
 
 	  title(game.translate("results.sprint.times"), Pos{0, 5}),
 	  noGames(game.translate("sprint.times.nogames"), Pos{}, {0.75f, 0.75f}),
-	  page(sdsempty(), Pos{10, 10}, {0.8f, 0.8f}),
-	  selectedText(sdsempty(), Pos{0, SCREEN_HEIGHT - TABLE_Y + 10},
+	  page(String::empty(), Pos{10, 10}, {0.8f, 0.8f}),
+	  selectedText(String::empty(), Pos{0, SCREEN_HEIGHT - TABLE_Y + 10},
 				   {0.65f, 0.65f}) {
 	// Games::all joins the load thread
 	if (game.getGames().all().empty()) {
@@ -46,10 +46,6 @@ SprintTimes::SprintTimes()
 
 	updateInfoText(games[selected]);
 	updateSelectedText();
-}
-
-SprintTimes::~SprintTimes() noexcept {
-	sdsfree(infoFormat);
 }
 
 void SprintTimes::genValues() {
@@ -185,7 +181,7 @@ void SprintTimes::updateSelectedText() {
 void SprintTimes::updateInfoText(const SavedGame& saved) {
 	char date[60];
 	saved.dateString(date, 60);
-	page.setText(sdscatprintf(sdsempty(), infoFormat, saved.lines, saved.time,
+	page.setText(sdscatprintf(sdsempty(), infoFormat.s, saved.lines, saved.time,
 							  saved.pps, date));
 }
 

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -20,6 +20,10 @@
  * IN THE SOFTWARE.
  */
 
+extern "C" {
+#include <3ds/console.h>
+}
+
 #include <3dstris/util/fs.hpp>
 #include <3dstris/util/log.hpp>
 #include <3dstris/version.hpp>
@@ -28,6 +32,12 @@ Log::Log() noexcept {
 	static const FS_Path HOMEBREW_PATH = fsMakePath(PATH_ASCII, "/3ds/");
 	static const FS_Path GAME_PATH = fsMakePath(PATH_ASCII, "/3ds/3dstris/");
 	static constexpr auto LOG_PATH = "sdmc:/3ds/3dstris/log.log";
+
+#ifndef NDEBUG
+	consoleDebugInit(debugDevice_3DMOO);
+	setLevel(Log::Level::DEBUG);
+	setQuiet(false);
+#endif
 
 	// Please don't use any of the LOG macros here
 

--- a/src/util/text.cpp
+++ b/src/util/text.cpp
@@ -1,31 +1,13 @@
 #include <3dstris/util/draw.hpp>
 #include <3dstris/util/text.hpp>
 
-Text::Text(sds text, const Pos pos, const Vector2f scale,
+Text::Text(String&& text, const Pos pos, const Vector2f scale,
 		   const Color& color) noexcept
 	: pos(pos),
 	  _scale(scale),
 	  textBuffer(C2D_TextBufNew(sdslen(text))),
 	  color(color) {
-	setText(text);
-}
-Text::Text(const char* __restrict text, const Pos pos, const Vector2f scale,
-		   const Color& color) noexcept
-	: Text(sdsnew(text), pos, scale, color) {}
-
-Text::~Text() noexcept {
-	C2D_TextBufDelete(textBuffer);
-	sdsfree(text);
-}
-Text::Text(Text&& other) noexcept
-	: pos(other.pos),
-	  _scale(other._scale),
-	  text(other.text),
-	  textBuffer(other.textBuffer),
-	  textObject(other.textObject),
-	  color(other.color) {
-	other.text = nullptr;
-	other.textBuffer = nullptr;
+	setText(std::forward<String>(text));
 }
 
 void Text::draw(const float depth) const noexcept {
@@ -69,13 +51,12 @@ void Text::scale(const float cw, const float max) noexcept {
 	setScale({scale, scale});
 }
 
-void Text::setText(sds text) noexcept {
-	sdsfree(this->text);
-	this->text = text;
+void Text::setText(String&& text) noexcept {
+	this->text = std::forward<String>(text);
 
 	C2D_TextBufClear(textBuffer);
 
-	const size_t textLen = sdslen(text);
+	const size_t textLen = sdslen(this->text);
 	if (C2D_TextBufGetNumGlyphs(textBuffer) < textLen) {
 		textBuffer = C2D_TextBufResize(textBuffer, textLen);
 	}
@@ -84,7 +65,7 @@ void Text::setText(sds text) noexcept {
 	C2D_TextOptimize(&textObject);
 }
 
-sds Text::getText() const noexcept {
+const String& Text::getText() const noexcept {
 	return text;
 }
 


### PR DESCRIPTION
A very, very thin `sds` wrapper. Performance should be about the same. Dealing with copy/move constructors and operators is significantly easier.
The code for some of this isn't exactly perfect. I'd like to improve upon the text-related areas of the codebase, especially the `Text` class, possibly in a future PR. I will most likely wrap around some of the `sds` functions to make some things like formatting ~and creating a string from `sdscatfmt`/`sdscatprintf`~ easier.

While working on this PR, I found a small memory leak in ToggleButton. The static `getText` function in the source file for ToggleButton was leaking memory by never freeing the string returned by `Game::translate`. There might have been other small leaks that I didn't notice, too, however any other leaks should hopefully be resolved as of this PR.

- [x] Test every state for segfaults and any other possible issues

Resolves #95 